### PR TITLE
Add !rngkey game

### DIFF
--- a/scripts/hubot-netrunnerdb-cards.coffee
+++ b/scripts/hubot-netrunnerdb-cards.coffee
@@ -770,6 +770,34 @@ module.exports = (robot) ->
 
         res.send cardString
 
+    robot.hear /^!rngkey (\d+)$/i, (res) ->
+      # get the guess
+      guess = parseInt(res.match[1])
+
+      # get legal accesses from a corp
+      packs = robot.brain.get('packs-en')
+      cycles = robot.brain.get('cycles-en')
+      bannedCards = robot.brain.get('bannedCards-en')
+      cards = robot.brain.get('cards-en').filter((card) ->
+        return card.side_code == "corp" && cycles[packs[card.pack_code].cycle_code].position != 0 && !cycles[packs[card.pack_code].cycle_code].rotated && card.title not in bannedCards && packs[card.pack_code].date_release != null && card.type_code != "identity"
+      )
+
+      # pick the random access
+      access = cards[Math.floor(Math.random() * cards.length)]
+
+      #determine the result
+      if access.type_code == "agenda"
+        cost = access.advancement_cost
+      else if access.type_code in ["asset", "operation", "ice", "upgrade"]
+        cost = access.cost
+
+      if cost == guess
+        result = "you win!"
+      else
+        result = "you lose!"
+
+      res.send "You guessed: " + guess + ":credit:. You accessed " + access.title + "! That's " + cost + ":credit:, " + result
+
     # robot.hear /^!mwl$/i, (res) ->
     #     mwl = robot.brain.get('mwl-en')
     #     restrictedCards = robot.brain.get('restrictedCards-en')


### PR DESCRIPTION
Based on a suggestion/request from #uk and inspired by `!psi`:

Use RNG Key to access a corp card. Guess a value and access a
random corp card from the entire cardpool. If you get the cost
right, you win!

Example:
`!rngkey 1`
> You guessed: 1:credit:. You accessed Negotiator! That's 4:credit:, you lose!

`!rngkey 2`
> You guessed: 2:credit:. You accessed Zealous Judge! That's 2:credit:, you win!